### PR TITLE
google-cloud-bigquery-storage 2.26.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 
 build:
   number: 0
+  # we skip py<38 following along conda-forge, to avoid importlib-metadata
+  # which is needed for py37
   skip: true  # [py<38]
 
 requirements:
@@ -102,6 +104,8 @@ outputs:
 
   - name: {{ name }}-core
     build:
+      # we skip py<38 following along conda-forge, to avoid importlib-metadata
+      # which is needed for py37
       skip: true  # [py<38]
       script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ outputs:
         # noxfile.py#L38
         - mock
         # asyncmock not available
-        - asyncmock
+        # - asyncmock
         - pytest-asyncio
       source_files:
         - tests/unit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
 outputs:
   - name: {{ name }}
     build:
+      # we skip py<38 following along conda-forge, to avoid importlib-metadata
+      # which is needed for py37
       skip: true  # [py<38]
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,61 +1,79 @@
-{% set dependency_fastavro = "fastavro >=0.21.2" %}
-{% set dependency_pandas = "pandas >=0.17.1" %}
-{% set dependency_pyarrow = "pyarrow >=0.15.0" %}
 {% set name = "google-cloud-bigquery-storage" %}
-{% set version = "2.1.0" %}
-{% set sha256 = "7da8691d218e494e2688f3c72cf4249d504b0a55fe41cb1ac6e7903c1e03a3d4" %}
+{% set version = "2.26.0" %}
+{% set sha256 = "840275bd0a4b207c0ac821bcc6741406ffb3b5ef940fa05089a90eb4403453fa" %}
 
 package:
   name: {{ name|lower }}-split
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<38]
 
 requirements:
   host:
     - python
     - pip >=18.1
     - setuptools >=34.0.0
+    - wheel
+  run:
+    - python
 
 outputs:
   - name: {{ name }}
     build:
-      noarch: python
+      skip: true  # [py<38]
 
     requirements:
       host:
         - python
         - pip >=18.1
         - setuptools >=34.0.0
-
+        - wheel
       run:
+        - python
         - {{ name }}-core {{ version }}
-        - {{ dependency_pandas }}
-        - {{ dependency_fastavro }}
-        - {{ dependency_pyarrow }}
+        - pandas >=0.21.1
+        - fastavro >=0.21.2
+        - pyarrow >=0.15.0
 
     test:
       requires:
         - python
         - pip
+        - pytest
+        # noxfile.py#L38
+        - mock
+        # asyncmock not available
+        - asyncmock
+        - pytest-asyncio
+      source_files:
+        - tests/unit
       imports:
         - google
         - google.cloud
         - google.cloud.bigquery_storage
         - google.cloud.bigquery_storage_v1
         - google.cloud.bigquery_storage_v1.client
-        - google.cloud.bigquery_storage_v1.proto
+        - google.cloud.bigquery_storage_v1.exceptions
+        - google.cloud.bigquery_storage_v1.reader
+        - google.cloud.bigquery_storage_v1.services.big_query_read.async_client
         - google.cloud.bigquery_storage_v1.services.big_query_read.client
+        - google.cloud.bigquery_storage_v1.services.big_query_write.async_client
+        - google.cloud.bigquery_storage_v1.services.big_query_write.client
         - google.cloud.bigquery_storage_v1.types
+        - google.cloud.bigquery_storage_v1.types.storage
+        - google.cloud.bigquery_storage_v1.writer
       commands:
-        - python -m pip check
+        - pip check
+        # noxfile.py#L209
+        - set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python     # [win]
+        - export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python  # [not win]
+        - pytest -vv tests/unit
 
     about:
       home: https://github.com/googleapis/python-bigquery-storage
@@ -69,40 +87,42 @@ outputs:
 
         Supported Python Versions
         -------------------------
-        Python >= 3.6
+        Python >= 3.8
 
         Deprecated Python Versions
         --------------------------
-        Python == 2.7, Python == 3.5.
+        Python == 2.7, Python <= 3.7.
 
         The last version of this library compatible with Python 2.7
         and 3.5 is google-cloud-bigquery-storage==1.1.0.
-      doc_url: https://googleapis.dev/python/bigquerystorage/latest/index.html
+      doc_url: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
       dev_url: https://github.com/googleapis/python-bigquery-storage
 
   - name: {{ name }}-core
     build:
-      noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      skip: true  # [py<38]
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
     requirements:
       host:
         - python
         - pip >=18.1
         - setuptools >=34.0.0
-
+        - wheel
       run:
-        - python >=3.6
-        - google-api-core-grpc >=1.22.2,<2.0.0dev
-        - proto-plus >=1.4.0
-        - libcst >=0.2.5
-        # Workaround for https://github.com/conda-forge/aiohttp-feedstock/issues/43
-        - yarl <1.6.0,>=1.0
-
+        - python
+        - google-api-core-grpc >=1.34.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*
+        - proto-plus >=1.22.0,<2.0.0dev
+        - proto-plus >=1.22.2,<2.0.0dev # [py>310]
+        - protobuf >=3.20.2,<6.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+        - google-auth >=2.14.1,<3.0.0dev
       run_constrained:
-        - {{ dependency_pandas }}
-        - {{ dependency_fastavro }}
-        - {{ dependency_pyarrow }}
+        - pandas >=0.21.1
+        # importlib-metadata is required for Python 3.7 compatibility
+        # but we skip py<38
+        # - importlib-metadata >=1.0.0  # [py<38]
+        - fastavro >=0.21.2
+        - pyarrow >=0.15.0
 
     test:
       requires:
@@ -114,11 +134,17 @@ outputs:
         - google.cloud.bigquery_storage
         - google.cloud.bigquery_storage_v1
         - google.cloud.bigquery_storage_v1.client
-        - google.cloud.bigquery_storage_v1.proto
+        - google.cloud.bigquery_storage_v1.exceptions
+        - google.cloud.bigquery_storage_v1.reader
+        - google.cloud.bigquery_storage_v1.services.big_query_read.async_client
         - google.cloud.bigquery_storage_v1.services.big_query_read.client
+        - google.cloud.bigquery_storage_v1.services.big_query_write.async_client
+        - google.cloud.bigquery_storage_v1.services.big_query_write.client
         - google.cloud.bigquery_storage_v1.types
+        - google.cloud.bigquery_storage_v1.types.storage
+        - google.cloud.bigquery_storage_v1.writer
       commands:
-        - python -m pip check
+        - pip check
 
     about:
       home: https://github.com/googleapis/python-bigquery-storage
@@ -132,15 +158,15 @@ outputs:
 
         Supported Python Versions
         -------------------------
-        Python >= 3.6
+        Python >= 3.8
 
         Deprecated Python Versions
         --------------------------
-        Python == 2.7, Python == 3.5.
+        Python == 2.7, Python <= 3.6.
 
         The last version of this library compatible with Python 2.7
         and 3.5 is google-cloud-bigquery-storage==1.1.0.
-      doc_url: https://googleapis.dev/python/bigquerystorage/latest/index.html
+      doc_url: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
       dev_url: https://github.com/googleapis/python-bigquery-storage
 
 about:
@@ -148,11 +174,15 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: BigQuery Storage API client library
-  doc_url: https://googleapis.dev/python/bigquerystorage/latest/index.html
+  summary: Python Client for Google BigQuery Storage API
+  description: |
+    Python Client for Google BigQuery Storage API.
+  doc_url: https://cloud.google.com/python/docs/reference/bigquerystorage/latest/summary_overview
   dev_url: https://github.com/googleapis/python-bigquery-storage
 
 extra:
   recipe-maintainers:
+    - chalmerlowe
     - pshiko
     - tswast
+    - xhochy


### PR DESCRIPTION
google-cloud-bigquery-storage 2.26.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5617]
- dev_url (pypi): https://github.com/googleapis/python-bigquery-storage/tree/v2.26.0
- conda-forge: https://github.com/conda-forge/google-cloud-bigquery-storage-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/google-cloud-bigquery-storage/2.26.0
- pypi inspector: https://inspector.pypi.io/project/google-cloud-bigquery-storage/2.26.0

### Dependency for

- AnacondaRecipes/google-cloud-bigquery-feedstock#1

### Explanation of changes:

- new feedstock
- multi-output recipe
- upstream tests


[PKG-5617]: https://anaconda.atlassian.net/browse/PKG-5617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ