### PR TITLE
PKG-8099: google-cloud-bigquery-storage 2.26.0 (py313 rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -192,3 +192,5 @@ extra:
     - pshiko
     - tswast
     - xhochy
+  skip-lints:
+    - wrong_output_script_key

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # we skip py<38 following along conda-forge, to avoid importlib-metadata
   # which is needed for py37
   skip: true  # [py<38]


### PR DESCRIPTION
google-cloud-bigquery-storage 2.26.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8099]() 
- [Upstream repository](https://github.com/googleapis/python-bigquery-storage/tree/v2.26.0)

### Explanation of changes:

- py313 rebuild


[PKG-8099]: https://anaconda.atlassian.net/browse/PKG-8099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ